### PR TITLE
Chore/v24 version bump

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://stape.io/blog/facebook-leads-tag-for-server-gtm'
 versions:
+  - sha: 74a87274d97b76a476f20f3bf052752154fc004f
+    changeNotes: Update to API v24.
   - sha: 72b02066b6142f8a95e748fa97e16687722df349
     changeNotes: Update to API v22.
   - sha: 4d0860b4dc785b8b848da1e893da06d0c1f64df9

--- a/template.js
+++ b/template.js
@@ -15,7 +15,7 @@ const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
 const eventData = getAllEventData();
 
-const apiVersion = '22.0';
+const apiVersion = '24.0';
 const postUrl =
   'https://graph.facebook.com/v' +
   apiVersion +

--- a/template.tpl
+++ b/template.tpl
@@ -148,7 +148,7 @@ const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
 const eventData = getAllEventData();
 
-const apiVersion = '22.0';
+const apiVersion = '24.0';
 const postUrl =
   'https://graph.facebook.com/v' +
   apiVersion +
@@ -421,4 +421,5 @@ scenarios: []
 ___NOTES___
 
 Created on 03/04/2024, 14:11:51
+
 


### PR DESCRIPTION
Updated endpoint to v24. No changes in payload structure for CAPI for Leads in this version bump.